### PR TITLE
feat(chat): 添加多模态图片上传和预览功能

### DIFF
--- a/kunavatar/src/app/api/chat/route.ts
+++ b/kunavatar/src/app/api/chat/route.ts
@@ -225,7 +225,8 @@ async function handleNonStreamingChat({
           model,
           userId,
           agentId,
-          isAgentMode
+          isAgentMode,
+          lastUserMessage.images // 传递图片数据
         );
       }
 

--- a/kunavatar/src/app/api/chat/services/messageStorageService.ts
+++ b/kunavatar/src/app/api/chat/services/messageStorageService.ts
@@ -33,7 +33,8 @@ export class MessageStorageService {
     model: string,
     userId: string,
     agentId?: number,
-    isAgentMode: boolean = false
+    isAgentMode: boolean = false,
+    images?: string[]
   ): number {
     try {
       // 🎯 根据模式选择不同的表
@@ -44,7 +45,8 @@ export class MessageStorageService {
           role: 'user' as const,
           content: content,
           agent_id: agentId,
-          user_id: userId
+          user_id: userId,
+          images: images ? JSON.stringify(images) : undefined
         });
       } else {
         // 模型模式：使用 messages 表
@@ -53,7 +55,8 @@ export class MessageStorageService {
           role: 'user' as const,
           content: content,
           model: model,
-          user_id: userId
+          user_id: userId,
+          images: images ? JSON.stringify(images) : undefined
         });
       }
     } catch (error) {
@@ -185,7 +188,7 @@ export class MessageStorageService {
     try {
       for (const message of messages) {
         if (message.role === 'user') {
-          this.saveUserMessage(conversationId, message.content, model, userId, agentId, isAgentMode);
+          this.saveUserMessage(conversationId, message.content, model, userId, agentId, isAgentMode, message.images);
         } else if (message.role === 'assistant') {
           this.saveAssistantMessage(conversationId, message.content, model, userId, agentId, undefined, isAgentMode);
         }

--- a/kunavatar/src/app/api/chat/services/streamingChatHandler.ts
+++ b/kunavatar/src/app/api/chat/services/streamingChatHandler.ts
@@ -64,9 +64,7 @@ export class StreamingChatHandler {
          try {
            // 构建聊天请求
            const ollamaChatRequest = await StreamingChatHandler.buildChatRequest(chatRequest);
-           
-           console.log('发送聊天请求:', JSON.stringify(ollamaChatRequest, null, 2));
-           
+                      
            let retryWithoutTools = false;
            
            try {
@@ -279,7 +277,8 @@ export class StreamingChatHandler {
       if (msg.role === 'assistant' && 'tool_calls' in msg) {
         return {
           role: msg.role,
-          content: msg.content || '[助手使用了工具]'
+          content: msg.content || '[助手使用了工具]',
+          ...(msg.images && { images: msg.images }) // 保留图片字段
         };
       }
       
@@ -288,10 +287,11 @@ export class StreamingChatHandler {
         return null;
       }
       
-      // 保留其他消息
+      // 保留其他消息，包括图片字段
       return {
         role: msg.role,
-        content: msg.content
+        content: msg.content,
+        ...(msg.images && { images: msg.images }) // 保留图片字段
       };
     }).filter(msg => msg !== null) as ChatMessage[];
   }
@@ -313,7 +313,8 @@ export class StreamingChatHandler {
         chatRequest.model,
         chatRequest.userId,
         chatRequest.agentId,
-        isAgentMode
+        isAgentMode,
+        lastUserMessage.images // 传递图片数据
       );
     }
   }
@@ -383,8 +384,6 @@ export class StreamingChatHandler {
         });
       }
     }
-
-    console.log('🔧 构建的消息历史包含工具结果:', JSON.stringify(updatedMessages.slice(-3), null, 2));
 
     // 为工具调用后的对话也注入记忆上下文
     let messagesWithMemory = updatedMessages;

--- a/kunavatar/src/app/chat/components/ChatArea.tsx
+++ b/kunavatar/src/app/chat/components/ChatArea.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Bot, MessageCircle } from 'lucide-react';
 import { MessageList } from './MessageList';
 import Modal from '@/components/Modal';
+import ImagePreviewModal from './ImagePreviewModal';
 
 type ChatMode = 'model' | 'agent';
 
@@ -148,6 +149,29 @@ function ChatInterface({
     messageId: null,
   });
 
+  // 图片预览模态框状态
+  const [imagePreviewModal, setImagePreviewModal] = useState<{
+    isOpen: boolean;
+    imageUrl: string;
+    imageIndex: number;
+    images: string[];
+  }>({ isOpen: false, imageUrl: '', imageIndex: 0, images: [] });
+
+  // 处理图片预览
+  const handleImagePreview = (imageUrl: string, imageIndex: number, images: string[]) => {
+    setImagePreviewModal({
+      isOpen: true,
+      imageUrl,
+      imageIndex,
+      images
+    });
+  };
+
+  // 关闭图片预览
+  const handleCloseImagePreview = () => {
+    setImagePreviewModal({ isOpen: false, imageUrl: '', imageIndex: 0, images: [] });
+  };
+
   // 删除消息的处理函数
   const handleDeleteMessage = async (messageId: string) => {
     // 检查是否为临时ID（前端生成的ID）
@@ -241,6 +265,7 @@ function ChatInterface({
                 models={models} // 传递models参数
                 conversation={currentConversation} // 传递conversation参数
                 onDeleteMessage={handleDeleteMessage}
+                onImagePreview={handleImagePreview} // 添加图片预览回调
               />
             </div>
           ) : (
@@ -285,6 +310,15 @@ function ChatInterface({
       >
         <p>确定要删除这条消息吗？此操作无法撤销。</p>
       </Modal>
+
+      {/* 图片预览模态框 */}
+      <ImagePreviewModal
+        isOpen={imagePreviewModal.isOpen}
+        imageUrl={imagePreviewModal.imageUrl}
+        imageIndex={imagePreviewModal.imageIndex}
+        images={imagePreviewModal.images}
+        onClose={handleCloseImagePreview}
+      />
     </>
   );
 }

--- a/kunavatar/src/app/chat/components/ImagePreviewModal.tsx
+++ b/kunavatar/src/app/chat/components/ImagePreviewModal.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+import React from 'react';
+import { X, Download, ZoomIn, ZoomOut } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface ImagePreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imageUrl: string;
+  imageIndex: number;
+  images: string[];
+}
+
+export default function ImagePreviewModal({
+  isOpen,
+  onClose,
+  imageUrl,
+  imageIndex,
+  images
+}: ImagePreviewModalProps) {
+  const [scale, setScale] = React.useState(1);
+  const [position, setPosition] = React.useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = React.useState(false);
+  const imageRef = React.useRef<HTMLImageElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const dragStart = React.useRef({ x: 0, y: 0 });
+  const [currentIndex, setCurrentIndex] = React.useState(imageIndex);
+  const [imageLoading, setImageLoading] = React.useState(true);
+  const [imageError, setImageError] = React.useState(false);
+
+  const totalImages = images.length;
+  // 确保当前图片URL有正确的data前缀
+  const currentImageUrl = (() => {
+    const rawUrl = images[currentIndex] || imageUrl;
+    return rawUrl.startsWith('data:') ? rawUrl : `data:image/jpeg;base64,${rawUrl}`;
+  })();
+
+  // 导航函数
+  const handlePrevious = () => {
+    if (currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+      resetTransform();
+      setImageLoading(true);
+      setImageError(false);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentIndex < totalImages - 1) {
+      setCurrentIndex(currentIndex + 1);
+      resetTransform();
+      setImageLoading(true);
+      setImageError(false);
+    }
+  };
+
+  // 重置缩放
+  const resetTransform = () => {
+    setScale(1);
+    setPosition({ x: 0, y: 0 });
+  };
+
+  // 缩放控制
+  const handleZoomIn = () => {
+    setScale(prev => Math.min(prev * 1.5, 5));
+    setPosition({ x: 0, y: 0 });
+  };
+
+  const handleZoomOut = () => {
+    setScale(prev => Math.max(prev / 1.5, 0.5));
+    setPosition({ x: 0, y: 0 });
+  };
+
+  // 下载图片
+  const handleDownload = () => {
+    try {
+      // 检查是否是base64数据URL
+      if (currentImageUrl.startsWith('data:')) {
+        // 对于base64数据，直接使用数据URL
+        const link = document.createElement('a');
+        link.href = currentImageUrl;
+        
+        // 从数据URL中提取文件类型
+        const mimeMatch = currentImageUrl.match(/data:image\/([^;]+)/);
+        const extension = mimeMatch ? mimeMatch[1] : 'jpg';
+        
+        link.download = `image_${currentIndex + 1}.${extension}`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      } else {
+        // 对于普通URL，使用fetch下载
+        fetch(currentImageUrl)
+          .then(response => response.blob())
+          .then(blob => {
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `image_${currentIndex + 1}.jpg`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(url);
+          })
+          .catch(error => {
+            console.error('下载图片失败:', error);
+            alert('下载图片失败，请重试');
+          });
+      }
+    } catch (error) {
+      console.error('下载图片失败:', error);
+      alert('下载图片失败，请重试');
+    }
+  };
+
+  // 键盘事件处理
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Escape':
+          onClose();
+          break;
+        case 'ArrowLeft':
+          if (totalImages > 1) {
+            handlePrevious();
+          }
+          break;
+        case 'ArrowRight':
+          if (totalImages > 1) {
+            handleNext();
+          }
+          break;
+        case '+':
+        case '=':
+          e.preventDefault();
+          handleZoomIn();
+          break;
+        case '-':
+          e.preventDefault();
+          handleZoomOut();
+          break;
+        case '0':
+          e.preventDefault();
+          resetTransform();
+          break;
+      }
+    };
+
+    // 滚轮缩放事件处理 - 使用原生事件监听器以避免被动监听器问题
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      
+      if (e.deltaY < 0) {
+        handleZoomIn();
+      } else {
+        handleZoomOut();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    
+    // 为图片容器添加滚轮事件监听器，设置 passive: false
+    const imageContainer = document.getElementById('image-preview-container');
+    if (imageContainer) {
+      imageContainer.addEventListener('wheel', handleWheel, { passive: false });
+    }
+    
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (imageContainer) {
+        imageContainer.removeEventListener('wheel', handleWheel);
+      }
+    };
+  }, [isOpen, onClose, totalImages, currentIndex]);
+
+  // 重置状态当模态框关闭时
+  React.useEffect(() => {
+    if (!isOpen) {
+      resetTransform();
+      setImageLoading(true);
+      setImageError(false);
+    }
+  }, [isOpen]);
+
+  // 图片加载处理
+  const handleImageLoad = () => {
+    setImageLoading(false);
+    setImageError(false);
+  };
+
+  const handleImageError = () => {
+    setImageLoading(false);
+    setImageError(true);
+  };
+
+  const handlePointerMove = React.useCallback((e: PointerEvent) => {
+    if (!isDragging) return;
+    let newX = e.pageX - dragStart.current.x;
+    let newY = e.pageY - dragStart.current.y;
+    const imgRect = imageRef.current?.getBoundingClientRect();
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (imgRect && containerRect) {
+      const maxX = (imgRect.width - containerRect.width) / 2;
+      const maxY = (imgRect.height - containerRect.height) / 2;
+      newX = Math.max(-maxX, Math.min(newX, maxX));
+      newY = Math.max(-maxY, Math.min(newY, maxY));
+    }
+    setPosition({ x: newX, y: newY });
+  }, [isDragging]);
+
+  const handlePointerUp = React.useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  React.useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
+      document.addEventListener('pointerleave', handlePointerUp);
+      return () => {
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', handlePointerUp);
+        document.removeEventListener('pointerleave', handlePointerUp);
+      };
+    }
+  }, [isDragging, handlePointerMove, handlePointerUp]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-[9999] bg-black/95 flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          {/* 工具栏 */}
+          <div className="absolute top-4 left-1/2 transform -translate-x-1/2 z-20">
+            <div className="flex items-center gap-2 bg-black/70 backdrop-blur-sm rounded-lg px-4 py-2">
+              {/* 图片计数 */}
+              {totalImages > 1 && (
+                <span className="text-white text-sm">
+                  {currentIndex + 1} / {totalImages}
+                </span>
+              )}
+              
+              {/* 缩放控制 */}
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleZoomOut();
+                  }}
+                  className="p-2 text-white hover:bg-white/20 rounded transition-colors"
+                  title="缩小 (-)"
+                >
+                  <ZoomOut className="w-4 h-4" />
+                </button>
+                
+                <span className="text-white text-sm min-w-[3rem] text-center">
+                  {Math.round(scale * 100)}%
+                </span>
+                
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleZoomIn();
+                  }}
+                  className="p-2 text-white hover:bg-white/20 rounded transition-colors"
+                  title="放大 (+)"
+                >
+                  <ZoomIn className="w-4 h-4" />
+                </button>
+              </div>
+
+              {/* 下载按钮 */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDownload();
+                }}
+                className="p-2 text-white hover:bg-white/20 rounded transition-colors"
+                title="下载图片"
+              >
+                <Download className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* 关闭按钮 */}
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            className="absolute top-4 right-4 z-20 p-2 text-white hover:bg-white/20 rounded-full transition-colors"
+            title="关闭 (Esc)"
+          >
+            <X className="w-6 h-6" />
+          </button>
+
+          {/* 导航按钮 */}
+          {totalImages > 1 && (
+            <>
+              {/* 上一张 */}
+              {currentIndex > 0 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handlePrevious();
+                  }}
+                  className="absolute left-4 top-1/2 transform -translate-y-1/2 z-20 p-3 text-white hover:bg-white/20 rounded-full transition-colors"
+                  title="上一张 (←)"
+                >
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                  </svg>
+                </button>
+              )}
+
+              {/* 下一张 */}
+              {currentIndex < totalImages - 1 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleNext();
+                  }}
+                  className="absolute right-4 top-1/2 transform -translate-y-1/2 z-20 p-3 text-white hover:bg-white/20 rounded-full transition-colors"
+                  title="下一张 (→)"
+                >
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              )}
+            </>
+          )}
+
+          {/* 图片容器 */}
+          <div 
+            id="image-preview-container"
+            ref={containerRef}
+            className="relative w-full h-full flex items-center justify-center p-8 overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {imageError ? (
+              // 错误状态
+              <div className="text-center text-white">
+                <div className="text-6xl mb-4">⚠️</div>
+                <div className="text-lg mb-2">图片加载失败</div>
+                <div className="text-sm opacity-70">请检查图片是否有效</div>
+              </div>
+            ) : (
+              <>
+                {/* 加载状态 */}
+                {imageLoading && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/50 z-10">
+                    <div className="text-white text-center">
+                      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
+                      <div>加载中...</div>
+                    </div>
+                  </div>
+                )}
+                
+                {/* 图片 */}
+                <motion.img
+                  ref={imageRef}
+                  src={currentImageUrl}
+                  alt={`预览图片 ${currentIndex + 1}`}
+                  className={`max-w-full max-h-full object-contain select-none ${isDragging ? 'cursor-grabbing' : scale > 1 ? 'cursor-grab' : 'cursor-zoom-in'}`}
+                  style={{
+                    transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+                    transformOrigin: 'center',
+                    transition: 'transform 0.2s ease-out'
+                  }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (scale === 1) {
+                      handleZoomIn();
+                    } else {
+                      resetTransform();
+                    }
+                  }}
+                  onPointerDown={(e) => {
+                    if (scale <= 1) return;
+                    e.preventDefault();
+                    setIsDragging(true);
+                    dragStart.current = {
+                      x: e.pageX - position.x,
+                      y: e.pageY - position.y
+                    };
+                  }}
+                  onLoad={handleImageLoad}
+                  onError={handleImageError}
+                  draggable={false}
+                />
+              </>
+            )}
+          </div>
+
+          {/* 操作提示 */}
+          <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-20">
+            <div className="bg-black/70 backdrop-blur-sm rounded-lg px-4 py-2 text-white text-sm text-center">
+              <div className="flex items-center gap-4 text-xs opacity-70">
+                <span>点击放大/还原</span>
+                <span>滚轮缩放</span>
+                {totalImages > 1 && <span>← → 切换</span>}
+                <span>Esc 关闭</span>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/kunavatar/src/app/chat/components/ImageUpload.tsx
+++ b/kunavatar/src/app/chat/components/ImageUpload.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { ImageIcon, X, Upload } from 'lucide-react';
+
+interface ImageUploadProps {
+  images?: string[]; // 当前图片数组
+  onImagesChange: (images: string[]) => void;
+  disabled?: boolean;
+  maxImages?: number;
+  maxFileSize?: number; // 以字节为单位，默认5MB
+  className?: string;
+}
+
+interface UploadedImage {
+  id: string;
+  base64: string;
+  fileName: string;
+  size: number;
+}
+
+export function ImageUpload({
+  images = [],
+  onImagesChange,
+  disabled = false,
+  maxImages = 5,
+  maxFileSize = 5 * 1024 * 1024, // 5MB
+  className = ''
+}: ImageUploadProps) {
+  const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 将文件转换为base64
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        // 移除data:image/...;base64,前缀，只保留base64数据
+        const base64Data = result.split(',')[1];
+        resolve(base64Data);
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  };
+
+  // 验证文件类型和大小
+  const validateFile = (file: File): string | null => {
+    // 检查文件类型
+    if (!file.type.startsWith('image/')) {
+      return '只能上传图片文件';
+    }
+
+    // 检查文件大小
+    if (file.size > maxFileSize) {
+      const maxSizeMB = maxFileSize / (1024 * 1024);
+      return `文件大小不能超过 ${maxSizeMB}MB`;
+    }
+
+    return null;
+  };
+
+  // 处理文件上传
+  const handleFiles = async (files: FileList) => {
+    if (disabled) return;
+
+    const fileArray = Array.from(files);
+    const remainingSlots = maxImages - uploadedImages.length;
+    
+    if (fileArray.length > remainingSlots) {
+      alert(`最多只能上传 ${maxImages} 张图片，当前还可以上传 ${remainingSlots} 张`);
+      return;
+    }
+
+    const newImages: UploadedImage[] = [];
+
+    for (const file of fileArray) {
+      const error = validateFile(file);
+      if (error) {
+        alert(`文件 "${file.name}" ${error}`);
+        continue;
+      }
+
+      try {
+        const base64 = await fileToBase64(file);
+        newImages.push({
+          id: `${Date.now()}-${Math.random()}`,
+          base64,
+          fileName: file.name,
+          size: file.size
+        });
+      } catch (error) {
+        console.error('文件转换失败:', error);
+        alert(`文件 "${file.name}" 转换失败`);
+      }
+    }
+
+    if (newImages.length > 0) {
+      const updatedImages = [...uploadedImages, ...newImages];
+      setUploadedImages(updatedImages);
+      onImagesChange(updatedImages.map(img => img.base64));
+    }
+  };
+
+  // 删除图片
+  const removeImage = (imageId: string) => {
+    const updatedImages = uploadedImages.filter(img => img.id !== imageId);
+    setUploadedImages(updatedImages);
+    onImagesChange(updatedImages.map(img => img.base64));
+  };
+
+  // 处理点击上传
+  const handleUploadClick = () => {
+    if (disabled) return;
+    fileInputRef.current?.click();
+  };
+
+  // 处理拖拽
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!disabled) {
+      setIsDragging(true);
+    }
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    
+    if (disabled) return;
+    
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      handleFiles(files);
+    }
+  };
+
+  // 格式化文件大小
+  const formatFileSize = (bytes: number): string => {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  };
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {/* 上传区域 */}
+      <div
+        className={`
+          relative border-2 border-dashed rounded-lg p-4 transition-colors cursor-pointer
+          ${isDragging 
+            ? 'border-blue-400 bg-blue-50 dark:bg-blue-900/20' 
+            : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
+          }
+          ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+        `}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onClick={handleUploadClick}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => e.target.files && handleFiles(e.target.files)}
+          disabled={disabled}
+        />
+        
+        <div className="flex flex-col items-center justify-center space-y-2 text-center">
+          <Upload className="w-8 h-8 text-gray-400" />
+          <div className="text-sm text-gray-600 dark:text-gray-400">
+            <span className="font-medium text-blue-600 dark:text-blue-400">点击上传</span>
+            {' '}或拖拽图片到此处
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-500">
+            支持 JPG、PNG、GIF 等格式，单个文件不超过 {formatFileSize(maxFileSize)}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-500">
+            最多上传 {maxImages} 张图片 ({uploadedImages.length}/{maxImages})
+          </div>
+        </div>
+      </div>
+
+      {/* 已上传的图片预览 */}
+      {uploadedImages.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            已上传的图片 ({uploadedImages.length})
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {uploadedImages.map((image) => (
+              <div
+                key={image.id}
+                className="relative group bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden aspect-square"
+              >
+                <img
+                  src={`data:image/jpeg;base64,${image.base64}`}
+                  alt={image.fileName}
+                  className="w-full h-full object-cover"
+                />
+                
+                {/* 删除按钮 */}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeImage(image.id);
+                  }}
+                  className="absolute top-1 right-1 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                  disabled={disabled}
+                >
+                  <X className="w-3 h-3" />
+                </button>
+                
+                {/* 文件信息 */}
+                <div className="absolute bottom-0 left-0 right-0 bg-black bg-opacity-50 text-white text-xs p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="truncate">{image.fileName}</div>
+                  <div>{formatFileSize(image.size)}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/kunavatar/src/app/chat/components/input-controls/ImageUploadControl.tsx
+++ b/kunavatar/src/app/chat/components/input-controls/ImageUploadControl.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { ImageIcon } from 'lucide-react';
+import { BaseControlButton } from './BaseControlButton';
+
+interface ImageUploadControlProps {
+  onImagesSelected: (files: FileList) => void;
+  disabled?: boolean;
+  hasImages?: boolean;
+  imageCount?: number;
+  maxImages?: number;
+  tooltip?: string;
+  
+  // 模型验证相关
+  isCheckingModel?: boolean;
+  modelSupportsVision?: boolean | null;
+  onValidationError?: (title: string, message: string) => void;
+}
+
+export function ImageUploadControl({
+  onImagesSelected,
+  disabled = false,
+  hasImages = false,
+  imageCount = 0,
+  maxImages = 5,
+  tooltip = '上传图片',
+  isCheckingModel = false,
+  modelSupportsVision = null,
+  onValidationError
+}: ImageUploadControlProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    // 如果模型不支持多模态，显示错误提示
+    if (modelSupportsVision === false) {
+      onValidationError?.(
+        '图片上传不可用', 
+        '当前模型不支持多模态功能，请选择支持图片识别的模型（如 llava、bakllava 等）。'
+      );
+      return;
+    }
+    
+    if (disabled) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      onImagesSelected(files);
+    }
+    // 清空input值，允许重复选择同一文件
+    e.target.value = '';
+  };
+
+  // 判断按钮是否应该被禁用
+  const isDisabled = disabled || isCheckingModel || modelSupportsVision === false;
+
+  // 确定工具提示文本
+  const getTooltip = () => {
+    if (isCheckingModel) {
+      return '正在检测模型多模态支持...';
+    }
+    if (modelSupportsVision === false) {
+      return '当前模型不支持图片识别，请选择其他模型';
+    }
+    return tooltip;
+  };
+
+  // 确定状态指示器
+  const getStatusIndicator = () => {
+    if (modelSupportsVision === null) return undefined;
+    
+    return {
+      status: modelSupportsVision ? 'success' as const : 'error' as const,
+      position: 'top-right' as const,
+      tooltip: modelSupportsVision ? '模型支持图片识别' : '模型不支持图片识别',
+    };
+  };
+
+  // 确定徽章
+  const getBadge = () => {
+    if (!hasImages || imageCount === 0) return undefined;
+    
+    return {
+      count: imageCount,
+      position: 'top-left' as const,
+      color: 'blue' as const,
+    };
+  };
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+        disabled={isDisabled}
+      />
+      
+      <BaseControlButton
+        onClick={handleClick}
+        disabled={isDisabled}
+        active={hasImages && (modelSupportsVision === true || modelSupportsVision === null)}
+        loading={isCheckingModel}
+        tooltip={getTooltip()}
+        badge={getBadge()}
+        statusIndicator={getStatusIndicator()}
+      >
+        <ImageIcon className="w-4 h-4" />
+      </BaseControlButton>
+    </>
+  );
+}

--- a/kunavatar/src/app/chat/components/input-controls/index.ts
+++ b/kunavatar/src/app/chat/components/input-controls/index.ts
@@ -4,8 +4,9 @@ export { ToolControl } from './ToolControl';
 export { MemoryControl } from './MemoryControl';
 export { ChatActionsControl } from './ChatActionsControl';
 export { PromptOptimizeControl } from './PromptOptimizeControl';
+export { ImageUploadControl } from './ImageUploadControl';
 
 // 类型定义
 export type { ChatStyle, DisplaySize } from './types';
 
-// InputControlsGroup 已合并到 ToolSettings 中 
+// InputControlsGroup 已合并到 ToolSettings 中

--- a/kunavatar/src/app/chat/hooks/useModelVisionValidation.ts
+++ b/kunavatar/src/app/chat/hooks/useModelVisionValidation.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+
+// 定义CustomModel类型
+interface CustomModel {
+  id: number;
+  base_model: string;
+  display_name: string;
+  capabilities?: string[];
+}
+
+export interface ModelVisionValidationParams {
+  selectedModel: string | null;
+  selectedAgent: any;
+  chatMode: 'model' | 'agent';
+  availableModels: CustomModel[];
+  // 通知函数
+  showWarning?: (title: string, message?: string) => void;
+  showError?: (title: string, message?: string) => void;
+}
+
+export interface ModelVisionValidationState {
+  modelSupportsVision: boolean | null;
+  isCheckingModel: boolean;
+}
+
+export interface ModelVisionValidationActions {
+  checkModelVisionSupport: (model: string) => boolean;
+  resetValidationState: () => void;
+  validateImageUpload: () => boolean;
+}
+
+export function useModelVisionValidation({
+  selectedModel,
+  selectedAgent,
+  chatMode,
+  availableModels,
+  showWarning,
+  showError
+}: ModelVisionValidationParams): ModelVisionValidationState & ModelVisionValidationActions {
+  const [modelSupportsVision, setModelSupportsVision] = useState<boolean | null>(null);
+  const [isCheckingModel, setIsCheckingModel] = useState(false);
+
+  // 重置验证状态
+  const resetValidationState = useCallback(() => {
+    setModelSupportsVision(null);
+    setIsCheckingModel(false);
+  }, []);
+
+  // 检查模型是否支持多模态（基于capabilities字段中的vision标签）
+  const checkModelVisionSupport = useCallback((model: string): boolean => {
+    if (!model) {
+      console.warn('模型名称为空，跳过多模态支持检测');
+      setModelSupportsVision(false);
+      return false;
+    }
+    
+    // 根据模型名称查找对应的模型信息
+    const modelInfo = availableModels.find(m => m.base_model === model);
+    
+    if (!modelInfo) {
+      console.warn(`未找到模型 ${model} 的信息，假设不支持多模态`);
+      setModelSupportsVision(false);
+      return false;
+    }
+    
+    // 检查capabilities字段是否包含"vision"
+    const supportsVision = modelInfo.capabilities?.includes('vision') || false;
+    
+    console.log(`模型 ${model} 多模态支持检测结果:`, supportsVision);
+    setModelSupportsVision(supportsVision);
+    return supportsVision;
+  }, [availableModels]);
+
+  // 验证图片上传功能
+  const validateImageUpload = useCallback((): boolean => {
+    const currentModel = chatMode === 'agent' 
+      ? selectedAgent?.model?.base_model 
+      : selectedModel;
+
+    const modeText = chatMode === 'agent' ? '智能体' : '模型';
+
+    if (!currentModel) {
+      showWarning?.('提示', `请先选择一个${modeText}`);
+      return false;
+    }
+
+    const supportsVision = checkModelVisionSupport(currentModel);
+    if (!supportsVision) {
+      showError?.(
+        '图片上传不可用', 
+        `当前${modeText}不支持多模态功能，请选择支持图片识别的模型（如 llava、bakllava 等）。`
+      );
+      return false;
+    }
+    
+    console.log(`✅ ${modeText}支持多模态，可以上传图片`);
+    return true;
+  }, [chatMode, selectedAgent, selectedModel, checkModelVisionSupport, showWarning, showError]);
+
+  // 当模型或智能体切换时重置验证状态
+  useEffect(() => {
+    resetValidationState();
+    
+    // 自动检查当前模型的多模态支持
+    const currentModel = chatMode === 'agent' 
+      ? selectedAgent?.model?.base_model 
+      : selectedModel;
+      
+    if (currentModel) {
+      checkModelVisionSupport(currentModel);
+    }
+  }, [selectedModel, selectedAgent?.model?.base_model, chatMode, checkModelVisionSupport, resetValidationState]);
+
+  return {
+    modelSupportsVision,
+    isCheckingModel,
+    checkModelVisionSupport,
+    resetValidationState,
+    validateImageUpload
+  };
+}

--- a/kunavatar/src/app/chat/page.tsx
+++ b/kunavatar/src/app/chat/page.tsx
@@ -659,7 +659,7 @@ function ChatPageContent() {
             currentConversationId={currentConversationId}
             onCreateConversation={handleCreateNewConversation}
             isCreatingConversation={isCreatingConversation}
-            onSendMessage={async (message: string) => {
+            onSendMessage={async (message: string, images?: string[]) => {
               let conversationId = currentConversationId;
               if (!conversationId) {
                 conversationId = await handleCreateNewConversation();
@@ -668,7 +668,7 @@ function ChatPageContent() {
                   return;
                 }
               }
-              await messageSender.sendMessage(message, conversationId);
+              await messageSender.sendMessage(message, conversationId, images);
             }}
             isStreaming={messageSender.isStreaming}
             onStopGeneration={messageSender.stopGeneration}
@@ -689,6 +689,14 @@ function ChatPageContent() {
             // 修复的模型工具支持检测
             isCheckingModel={isCheckingModel}
             modelSupportsTools={modelSupportsTools}
+            
+            // 图片上传相关
+            enableImageUpload={true}
+            maxImages={5}
+            maxImageSize={10 * 1024 * 1024} // 10MB
+            
+            // 模型数据（用于多模态验证）
+            availableModels={models || []}
           />
 
           {/* 🔧 工具面板 - 修复的数据传递 */}

--- a/kunavatar/src/lib/database/connection.ts
+++ b/kunavatar/src/lib/database/connection.ts
@@ -38,6 +38,8 @@ const executeInitialization = (db: Database.Database) => {
       sequence_number INTEGER DEFAULT 0,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       timestamp INTEGER, -- 毫秒级时间戳，用于精确排序
+      -- 图片相关字段
+      images TEXT, -- JSON数组格式存储base64编码的图片
       -- 工具调用相关字段
       tool_name TEXT, -- 工具名称
       tool_args TEXT, -- 工具参数 (JSON)
@@ -66,6 +68,8 @@ const executeInitialization = (db: Database.Database) => {
       sequence_number INTEGER DEFAULT 0,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
       timestamp INTEGER, -- 毫秒级时间戳，用于精确排序
+      -- 图片相关字段
+      images TEXT, -- JSON数组格式存储base64编码的图片
       -- 工具调用相关字段
       tool_name TEXT, -- 工具名称
       tool_args TEXT, -- 工具参数 (JSON)

--- a/kunavatar/src/lib/database/types.ts
+++ b/kunavatar/src/lib/database/types.ts
@@ -29,6 +29,9 @@ export interface Message {
   created_at: string;
   timestamp: number;
   
+  // 图片相关字段
+  images?: string[]; // Base64编码的图片数组
+  
   // 性能指标
   total_duration?: number;
   load_duration?: number;
@@ -61,6 +64,8 @@ export interface CreateMessageData {
   model?: string;
   user_id: string;
   sequence_number?: number;
+  // 图片相关字段
+  images?: string | null; // JSON数组格式存储base64编码的图片
   // 工具调用相关字段
   tool_name?: string;
   tool_args?: string; // JSON字符串

--- a/kunavatar/src/lib/ollama.ts
+++ b/kunavatar/src/lib/ollama.ts
@@ -56,6 +56,7 @@ export interface ChatMessage {
   content: string;
   tool_calls?: ToolCall[];
   tool_name?: string; // 新增：用于tool角色消息标识执行的工具名称
+  images?: string[]; // 新增：图片数据数组（Base64编码）
 }
 
 export interface ToolCall {


### PR DESCRIPTION
- 在ChatMessage接口和数据库表中添加images字段支持Base64图片数据
- 实现图片上传控件和图片预览模态框
- 添加模型多模态支持验证逻辑
- 修改消息发送逻辑以支持图片上传
- 在消息列表中显示上传的图片并支持预览
- 添加相关组件和hooks实现图片上传、预览和验证功能